### PR TITLE
GitHubトークン認証をgh CLIに置き換え

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,20 +2,25 @@
 
 # xbar GitHub PR Status Script Installation
 
-# Check arguments
-if [ $# -eq 0 ]; then
-    echo "Error: GitHub token not specified"
-    echo "Usage: $0 <github_token>"
-    exit 1
-fi
-
-GITHUB_TOKEN="$1"
-
 # Default xbar plugin directory path
 XBAR_PLUGIN_DIR="$HOME/Library/Application Support/xbar/plugins"
 
 # Script filename
 SCRIPT_NAME="github.10m.ts"
+
+# Check GitHub CLI (gh) is installed
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: GitHub CLI (gh) is not installed"
+    echo "Install it first, e.g.: brew install gh"
+    exit 1
+fi
+
+# Check gh is authenticated
+if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: GitHub CLI (gh) is not authenticated"
+    echo "Run the following and try again: gh auth login"
+    exit 1
+fi
 
 # Check and create plugin directory
 if [ ! -d "$XBAR_PLUGIN_DIR" ]; then
@@ -38,15 +43,8 @@ curl -L -o "$XBAR_PLUGIN_DIR/$SCRIPT_NAME" "https://raw.githubusercontent.com/ha
 if [ $? -eq 0 ]; then
     # Make executable
     chmod +x "$XBAR_PLUGIN_DIR/$SCRIPT_NAME"
-    
-    # Create vars.json file
-    VARS_FILE="$XBAR_PLUGIN_DIR/${SCRIPT_NAME}.vars.json"
-    echo "{" > "$VARS_FILE"
-    echo "    \"VAR_GITHUB_TOKEN\": \"$GITHUB_TOKEN\"" >> "$VARS_FILE"
-    echo "}" >> "$VARS_FILE"
-    
+
     echo "✓ Installation complete: $XBAR_PLUGIN_DIR/$SCRIPT_NAME"
-    echo "✓ Configuration file created: $VARS_FILE"
     echo ""
     echo "Next steps:"
     echo "1. Restart xbar"

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,12 @@ The following information can be displayed:
 ### Prerequisites
 
 *   [Deno](https://deno.land/) must be installed
+*   [GitHub CLI (`gh`)](https://cli.github.com/) must be installed and authenticated.
+    Authentication is handled by `gh`, so no personal access token is required.
+    ```bash
+    brew install gh   # if not installed
+    gh auth login     # authenticate via the browser
+    ```
 
 ### Installation
 
@@ -35,16 +41,23 @@ The following information can be displayed:
 
 ### Configuration
 
-1.  Click the Xbar icon in the menu bar and select "Open plugins..."
+No token configuration is needed. The plugin uses the GitHub CLI (`gh`) for
+authentication, so as long as `gh auth login` has been completed, it works out of
+the box.
 
-    <img src="images/setting.png" width="734" alt="Screenshot">
+1.  Make sure you are authenticated with the GitHub CLI:
+    ```bash
+    gh auth status
+    ```
+    If you are not logged in, run `gh auth login` and follow the browser prompts.
+    The required scopes (`repo` for private repositories) are requested automatically
+    during login.
 
-2.  Find `github.10m.ts` in the plugin list and configure it:
-    *   **Setting up GitHub Token:** Configure the personal access token required for the plugin to access the GitHub API. You can create a token from the [GitHub settings page](https://github.com/settings/tokens). Required scopes are `repo` (if including private repositories) or `public_repo` (for public repositories only)
+2.  Refresh the plugin by selecting "Refresh all plugins" from the Xbar menu or
+    "Refresh" from the individual plugin menu.
 
-    <img src="images/setting2.png" width="856" alt="Screenshot">
-
-3.  After configuration, refresh the plugin by selecting "Refresh all plugins" from the Xbar menu or "Refresh" from the individual plugin menu
+> **Note:** If you see a red `●` with "GitHub CLI (gh) is required", install `gh`
+> and run `gh auth login`.
 
 # Contributing
 

--- a/src/github.10m.ts
+++ b/src/github.10m.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S -P/${HOME}/.deno/bin:/opt/homebrew/bin deno run --allow-net=api.github.com --allow-env
+#!/usr/bin/env -S -P/${HOME}/.deno/bin:/opt/homebrew/bin PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${HOME}/.deno/bin deno run --allow-run=gh
 /// <reference lib="deno.ns" />
  
 // <xbar.title>GitHub Notifications</xbar.title>
@@ -9,7 +9,6 @@
 // <xbar.image></xbar.image>
 // <xbar.dependencies>deno</xbar.dependencies>
 // <xbar.abouturl>https://github.com/haradakunihiko/xbar</xbar.abouturl>
-// <xbar.var>string(VAR_GITHUB_TOKEN=""): GITHUB API token to get access to remote data.</xbar.var>
 
 import { xbar, separator } from "https://deno.land/x/xbar@v2.1.0/mod.ts";
 
@@ -41,33 +40,49 @@ const ICON_GITHUB_FAILURE = 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABJ0l
 const ICON_GITHUB_PENDING = 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABF0lEQVR4AZVTwXGDMBDkYf8p4WaEZw4y0qgEd5ASkg5SQlJBSCpIOsgvPF2CS3AJlKDcCk4WY+zIDMvd6XZXQohq7SKi2nT2q+nc2LQuCI6G3dMadzEGoZAhuI4H2y9EWuy6zv8rnlYTTOtOqotxObP9uWo0vdIR/YUJBhTRUR7ETBLSTeRrFMSelBs55H2tA4gg3ULDfg/ejLEyrf2ei2BKdlrclY9YZZ8qSK/oFk3ch8lg3tlYFMkrTJoZdC4VcngeCz3ONMP2GbMrzp07sihm94Zvi3zXupc1+fC+eR36bVAkjgg/ICRmkvyEPDWzRIVZPKT2LaGSMuHlKkBSk9IV/H5uL/9QYh+PKgzXMPSbg2AU7NH/A1pvtWWw89UmAAAAAElFTkSuQmCC';
 
 
-async function githubGraphQL<T>(query: string, variables: Record<string, unknown> = {}): Promise<GraphQLResponse<T>> {
-	const TOKEN = Deno.env.get('VAR_GITHUB_TOKEN');
-	
-	const headers = {
-		'Authorization': `token ${TOKEN}`,
-		'Content-Type': 'application/json',
-	};
-	
-	const res = await fetch('https://api.github.com/graphql', {
-		method: 'POST',
-		headers,
-		body: JSON.stringify({ query, variables }),
-	});
-	
-	if (!res.ok) {
-		throw new Error(`GraphQL API error: ${res.statusText}`);
+async function githubGraphQL<T>(query: string, variables: Record<string, string> = {}): Promise<GraphQLResponse<T>> {
+	// Use the GitHub CLI (`gh`) so authentication is handled by `gh auth login`
+	// instead of a personal access token. `gh api graphql` reuses the credentials
+	// stored in the keychain, so no token needs to be configured in xbar.
+	const args = ['api', 'graphql', '-f', `query=${query}`];
+	for (const [key, value] of Object.entries(variables)) {
+		args.push('-f', `${key}=${value}`);
 	}
-	
-	return await res.json();
+
+	const command = new Deno.Command('gh', {
+		args,
+		stdout: 'piped',
+		stderr: 'piped',
+	});
+	const { code, stdout, stderr } = await command.output();
+
+	if (code !== 0) {
+		throw new Error(`gh api error: ${new TextDecoder().decode(stderr).trim()}`);
+	}
+
+	return JSON.parse(new TextDecoder().decode(stdout));
+}
+
+async function isGhAuthenticated(): Promise<boolean> {
+	try {
+		const { code } = await new Deno.Command('gh', {
+			args: ['auth', 'status'],
+			stdout: 'null',
+			stderr: 'null',
+		}).output();
+		return code === 0;
+	} catch {
+		// `gh` is not installed / not on PATH
+		return false;
+	}
 }
 
 async function fetchIssues(params: {[index: string]: string}): Promise<IssueResponse> {
 	const searchQuery = Object.keys(params).map(k => `${k}:${params[k]}`).join(' ');
 	
 	const query = `
-		query SearchIssues($query: String!) {
-			search(query: $query, type: ISSUE, first: 100) {
+		query SearchIssues($searchQuery: String!) {
+			search(query: $searchQuery, type: ISSUE, first: 100) {
 				issueCount
 				edges {
 					node {
@@ -106,7 +121,7 @@ async function fetchIssues(params: {[index: string]: string}): Promise<IssueResp
 		}
 	`;
 	
-	const result = await githubGraphQL<SearchIssuesResponse>(query, { query: searchQuery });
+	const result = await githubGraphQL<SearchIssuesResponse>(query, { searchQuery });
 	
 	if (!result.data) {
 		throw new Error('Failed to fetch issues');
@@ -214,9 +229,7 @@ function getIconForItem(item: IssueItem): string {
 
 
 async function main() {
-	const TOKEN = Deno.env.get('VAR_GITHUB_TOKEN')
-	if (!TOKEN) {
-		
+	if (!(await isGhAuthenticated())) {
 		xbar([
 			{
 				text: '●',
@@ -224,7 +237,7 @@ async function main() {
 			},
 			separator,
 			{
-				text: 'Open Plugin... in menu bar and set github token'
+				text: 'GitHub CLI (gh) is required. Install it and run: gh auth login'
 			}
 		]);
 		return;


### PR DESCRIPTION
## 背景 / 目的
tokenからghコマンドでの認証に切り替え

## 変更内容

- **`src/github.10m.ts`**
  - `fetch` + `Authorization: token ...` ヘッダーを廃止し、`gh api graphql` をサブプロセス実行する方式に変更
  - shebang を `--allow-net=api.github.com --allow-env` → `--allow-run=gh` に変更。xbarの最小PATH環境下でも `gh` を解決できるよう `PATH=` を明示
  - 認証チェックを `VAR_GITHUB_TOKEN` の有無判定 → `gh auth status` の終了コード判定 (`isGhAuthenticated()`) に置換
  - `gh` の予約フィールド `query` と衝突するため、GraphQL変数 `$query` → `$searchQuery` にリネーム
  - `<xbar.var>VAR_GITHUB_TOKEN</xbar.var>` 行を削除
- **`install.sh`**: トークン引数 / `vars.json` 生成を廃止し、`gh` のインストール&認証チェックに変更
- **`readme.md`**: トークン作成手順を `gh auth login` 案内に置換

## 検証

- `deno check` 通過
- `env -i` によるクリーン環境（xbar相当の最小PATH）で実行 → PR一覧・CIステータスアイコン・レビュー待ちが正常表示
- gh未インストール/未認証時 → 赤い `●` +「Install it and run: gh auth login」を表示

## 利用者への影響

- 各マシンで `gh` のインストール + `gh auth login` が必要になる
- Deno権限が `--allow-net`(狭) → `--allow-run=gh`(プロセス実行) に変化

🤖 Generated with [Claude Code](https://claude.com/claude-code)